### PR TITLE
Add new market data and GTT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ If you want to use the hosted version, you can use the following config:
 | `GetOrderCharges()`          | [ ]                | Not yet implemented                             |
 | **GTT Orders**               |                    |                                                 |
 | `GetGTTs()`                  | [x]                | Implemented as `get_gtts` tool                  |
-| `GetGTT()`                   | [ ]                | Not yet implemented                             |
+| `GetGTT()`                   | [x]                | Implemented as `get_gtt` tool                   |
 | `PlaceGTT()`                 | [x]                | Implemented as `place_gtt_order` tool           |
 | `ModifyGTT()`                | [x]                | Implemented as `modify_gtt_order` tool          |
 | `DeleteGTT()`                | [x]                | Implemented as `delete_gtt_order` tool          |
 | **Market Data Methods**      |                    |                                                 |
 | `GetQuote()`                 | [x]                | Implemented as `get_quotes` tool                |
 | `GetHistoricalData()`        | [x]                | Implemented as `get_historical_data` tool       |
-| `GetLTP()`                   | [ ]                | Not yet implemented                             |
-| `GetOHLC()`                  | [ ]                | Not yet implemented                             |
+| `GetLTP()`                   | [x]                | Implemented as `get_ltp` tool                   |
+| `GetOHLC()`                  | [x]                | Implemented as `get_ohlc` tool                  |
 | `GetInstruments()`           | [-]                | Won't implement. Use `instruments_search` tool. |
 | `GetInstrumentsByExchange()` | [-]                | Won't implement                                 |
 | `GetAuctionInstruments()`    | [ ]                | Not yet implemented                             |

--- a/mcp/get_tools.go
+++ b/mcp/get_tools.go
@@ -326,3 +326,52 @@ func (*GTTOrdersTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}, nil
 	}
 }
+
+type GTTTool struct{}
+
+func (*GTTTool) Tool() mcp.Tool {
+	return mcp.NewTool("get_gtt",
+		mcp.WithDescription("Get a single GTT order by trigger ID"),
+		mcp.WithNumber("trigger_id",
+			mcp.Description("Trigger ID of the GTT order"),
+			mcp.Required(),
+		),
+	)
+}
+
+func (*GTTTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sess := server.ClientSessionFromContext(ctx)
+
+		kc, err := manager.GetSession(sess.SessionID())
+		if err != nil {
+			log.Println("error getting session", err)
+			return nil, err
+		}
+
+		args := request.Params.Arguments
+		triggerID := assertInt(args["trigger_id"])
+
+		gtt, err := kc.Kite.Client.GetGTT(triggerID)
+		if err != nil {
+			log.Println("error getting GTT order", err)
+			return nil, err
+		}
+
+		v, err := json.Marshal(gtt)
+		if err != nil {
+			log.Println("error marshalling GTT order", err)
+			return nil, err
+		}
+
+		gttJSON := string(v)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{
+					Type: "text",
+					Text: gttJSON,
+				},
+			},
+		}, nil
+	}
+}

--- a/mcp/market_tools.go
+++ b/mcp/market_tools.go
@@ -258,3 +258,107 @@ func (*HistoricalDataTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}, nil
 	}
 }
+
+type LTPTool struct{}
+
+func (*LTPTool) Tool() mcp.Tool {
+	return mcp.NewTool("get_ltp",
+		mcp.WithDescription("Get last traded price for instruments"),
+		mcp.WithArray("instruments",
+			mcp.Description("Eg. ['NSE:INFY', 'NSE:SBIN']"),
+			mcp.Required(),
+			mcp.Items(map[string]any{
+				"type": "string",
+			}),
+		),
+	)
+}
+
+func (*LTPTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sess := server.ClientSessionFromContext(ctx)
+
+		kc, err := manager.GetSession(sess.SessionID())
+		if err != nil {
+			log.Println("error getting session", err)
+			return nil, err
+		}
+
+		args := request.Params.Arguments
+		instruments := assertStringArray(args["instruments"])
+
+		ltpData, err := kc.Kite.Client.GetLTP(instruments...)
+		if err != nil {
+			log.Println("error getting LTP", err)
+			return nil, err
+		}
+
+		v, err := json.Marshal(ltpData)
+		if err != nil {
+			log.Println("error marshalling LTP data", err)
+			return nil, err
+		}
+
+		ltpJSON := string(v)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{
+					Type: "text",
+					Text: ltpJSON,
+				},
+			},
+		}, nil
+	}
+}
+
+type OHLCTool struct{}
+
+func (*OHLCTool) Tool() mcp.Tool {
+	return mcp.NewTool("get_ohlc",
+		mcp.WithDescription("Get OHLC data for instruments"),
+		mcp.WithArray("instruments",
+			mcp.Description("Eg. ['NSE:INFY', 'NSE:SBIN']"),
+			mcp.Required(),
+			mcp.Items(map[string]any{
+				"type": "string",
+			}),
+		),
+	)
+}
+
+func (*OHLCTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sess := server.ClientSessionFromContext(ctx)
+
+		kc, err := manager.GetSession(sess.SessionID())
+		if err != nil {
+			log.Println("error getting session", err)
+			return nil, err
+		}
+
+		args := request.Params.Arguments
+		instruments := assertStringArray(args["instruments"])
+
+		ohlcData, err := kc.Kite.Client.GetOHLC(instruments...)
+		if err != nil {
+			log.Println("error getting OHLC", err)
+			return nil, err
+		}
+
+		v, err := json.Marshal(ohlcData)
+		if err != nil {
+			log.Println("error marshalling OHLC data", err)
+			return nil, err
+		}
+
+		ohlcJSON := string(v)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{
+					Type: "text",
+					Text: ohlcJSON,
+				},
+			},
+		}, nil
+	}
+}

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -24,12 +24,15 @@ var (
 		&TradesTool{},
 		&OrdersTool{},
 		&GTTOrdersTool{},
+		&GTTTool{},
 		&MFHoldingsTool{},
 
 		// Tools for market data
 		&QuotesTool{},
 		&InstrumentsSearchTool{},
 		&HistoricalDataTool{},
+		&LTPTool{},
+		&OHLCTool{},
 
 		// Tools that post data to Kite Connect
 		&PlaceOrderTool{},


### PR DESCRIPTION
## Summary
- implement `get_ltp` and `get_ohlc` market data tools
- implement `get_gtt` tool for fetching a single GTT order
- expose new tools in `mcp` package
- document tools in README

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841d4aaa334833182a661e4f70f8d4d